### PR TITLE
Add in TPU chipcount metric

### DIFF
--- a/hack/example-tpu-jobset-multi-v5e.yaml
+++ b/hack/example-tpu-jobset-multi-v5e.yaml
@@ -1,0 +1,74 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: ex-multi-2rj-4x4-2x2-20-spot
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
+spec:
+  failurePolicy:
+    maxRestarts: 2
+  replicatedJobs:
+    - name: rs-aa-spot
+      replicas: 1
+      template:
+        spec:
+          parallelism: 4 # num node per node pool
+          completions: 4
+          backoffLimit: 0
+          template:
+            spec:
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 4x4
+                cloud.google.com/gke-spot: "true"
+              tolerations:
+              - key: cloud.google.com/gke-spot
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
+              containers:
+              - name: jax-tpu
+                image: ubuntu
+                ports:
+                - containerPort: 8471
+                - containerPort: 8080
+                command:
+                - bash
+                - -c
+                - |
+                  sleep 1200
+                resources:
+                  limits:
+                    google.com/tpu: 4
+    - name: rs-bb-spot
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1 # num node per node pool
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 2x2
+                cloud.google.com/gke-spot: "true"
+              tolerations:
+              - key: cloud.google.com/gke-spot
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
+              containers:
+              - name: jax-tpu
+                image: ubuntu
+                ports:
+                - containerPort: 8471
+                - containerPort: 8080
+                command:
+                - bash
+                - -c
+                - |
+                  sleep 1200
+                resources:
+                  limits:
+                    google.com/tpu: 4

--- a/hack/example-tpu-jobset-single-v5e.yaml
+++ b/hack/example-tpu-jobset-single-v5e.yaml
@@ -1,0 +1,42 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: example-single-v5e-2x2-spot
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
+spec:
+  failurePolicy:
+    maxRestarts: 3
+  replicatedJobs:
+    - name: rs-a
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1 # 1 node per node pool
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 2x2
+                cloud.google.com/gke-spot: "true"
+              tolerations:
+              - key: cloud.google.com/gke-spot
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
+              containers:
+              - name: jax-tpu
+                image: ubuntu
+                ports:
+                - containerPort: 8471
+                - containerPort: 8080
+                command:
+                - bash
+                - -c
+                - |
+                  sleep 1200
+                resources:
+                  limits:
+                    google.com/tpu: 4

--- a/internal/k8sutils/utils.go
+++ b/internal/k8sutils/utils.go
@@ -108,7 +108,7 @@ func TpuTopologyToChipCount(topo string) (int, error) {
 	// TODO: Do we need to validate expectedDims? GKE won't run the jobset if this is invalid?
 	split := strings.Split(topo, "x")
 	if split == nil {
-		return -1, fmt.Errorf("invalid topology: %v", topo)
+		return 0, fmt.Errorf("invalid topology: %v", topo)
 	}
 	product := 1
 	for _, s := range split {

--- a/internal/k8sutils/utils.go
+++ b/internal/k8sutils/utils.go
@@ -104,6 +104,23 @@ func IsNodeReady(node *corev1.Node) bool {
 	return false
 }
 
+func TpuTopologyToChipCount(topo string) (int, error) {
+	// TODO: Do we need to validate expectedDims? GKE won't run the jobset if this is invalid?
+	split := strings.Split(topo, "x")
+	if split == nil {
+		return -1, fmt.Errorf("invalid topology: %v", topo)
+	}
+	product := 1
+	for _, s := range split {
+		x, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid topology: %v, could not convert %q to int: %w", topo, s, err)
+		}
+		product *= x
+	}
+	return product, nil
+}
+
 func GetExpectedTPUNodePoolSize(node *corev1.Node) (int32, error) {
 	if node.Labels == nil {
 		return 0, fmt.Errorf("no annotations")

--- a/internal/k8sutils/utils_test.go
+++ b/internal/k8sutils/utils_test.go
@@ -9,6 +9,50 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestTpuTopologyToChipCount(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		topo          string
+		want          int
+		wantErrString string
+	}{
+		"empty": {
+			topo:          "",
+			wantErrString: "invalid topology",
+		},
+		"invalid topo": {
+			topo:          "abc",
+			wantErrString: "invalid topology",
+		},
+
+		"2x2": {
+			topo: "2x2",
+			want: 4,
+		},
+		"1x2x4": {
+			topo: "1x2x4",
+			want: 8,
+		},
+		"8x8x4": {
+			topo: "8x8x4",
+			want: 256,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := k8sutils.TpuTopologyToChipCount(c.topo)
+			if c.wantErrString != "" {
+				require.ErrorContains(t, err, c.wantErrString)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
 func TestGetExpectedTPUNodePoolSize(t *testing.T) {
 	t.Parallel()
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -48,6 +48,7 @@ func initMeterProvider(ctx context.Context, interval time.Duration) *metricsdk.M
 	)
 	if err != nil {
 		log.Error(err, "Error creating resource")
+		os.Exit(1)
 	}
 
 	// Create a MeterProvider and register it globally
@@ -126,7 +127,7 @@ func Init(ctx context.Context, r Reporter, interval time.Duration) func() {
 	)
 	if err != nil {
 		log.Error(err, "failed to register callback")
-		os.Exit(2)
+		os.Exit(1)
 	}
 
 	// Return a function that can be used to shutdown the provider.


### PR DESCRIPTION
Use report.NodePoolScheduling to get list of jobsets by nodepool. Get topology by nodepool as each nodepool might have a different topology and thus the jobsetSummaries topology cannot be relied.

TpuTopologyToChipCount doesn't validate expected dimensions as we assume this was done at least twice upstream (tpu provisioner and GKE control plane)