### PR TITLE
Add in TPU chip count metric

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,3 +27,9 @@ MegaMon was created to address shortcoming of using [kube-state-metrics](https:/
 * Difficult to derive high level metrics (like MTTR) when baseline metrics like Up-ness of jobset containers / nodes require their own complex queries.
 * Difficult or impossible to derive metrics like Time-to-provisioning / Time-to-first-up with promql
 * Current metrics are very large (they require all Nodes to be published as individual metrics and aggregated later)
+
+## Errata
+
+* If a jobset has multiple TPU topologies, only one of them will be in the
+  metric label
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,5 @@ MegaMon was created to address shortcoming of using [kube-state-metrics](https:/
 
 ## Errata
 
-* If a jobset has multiple TPU topologies, only one of them will be in the
-  metric label
-
+* If a jobset has multiple TPU topologies, the label value will be the TPU
+  topology of the last replicated job in the jobset.

--- a/hack/example-tpu-jobset-2rj-20-nonspot.yaml
+++ b/hack/example-tpu-jobset-2rj-20-nonspot.yaml
@@ -1,0 +1,62 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: ex-multi-2rj-20-nonspot
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
+spec:
+  failurePolicy:
+    maxRestarts: 2
+  replicatedJobs:
+    - name: rs-aaa
+      replicas: 1
+      template:
+        spec:
+          parallelism: 4 # num node per node pool
+          completions: 4
+          backoffLimit: 0
+          template:
+            spec:
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 4x4
+              containers:
+              - name: jax-tpu
+                image: ubuntu
+                ports:
+                - containerPort: 8471
+                - containerPort: 8080
+                command:
+                - bash
+                - -c
+                - |
+                  sleep 1000
+                resources:
+                  limits:
+                    google.com/tpu: 4
+    - name: rs-bbb
+      replicas: 1
+      template:
+        spec:
+          parallelism: 1 # num node per node pool
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 2x2
+              containers:
+              - name: jax-tpu
+                image: ubuntu
+                ports:
+                - containerPort: 8471
+                - containerPort: 8080
+                command:
+                - bash
+                - -c
+                - |
+                  sleep 1000
+                resources:
+                  limits:
+                    google.com/tpu: 4

--- a/hack/example-tpu-jobset-r2-16.yaml
+++ b/hack/example-tpu-jobset-r2-16.yaml
@@ -1,0 +1,62 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: ex-multi-2rj-r2-16-nonspot
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
+spec:
+  failurePolicy:
+    maxRestarts: 2
+  replicatedJobs:
+    - name: rs-aaa
+      replicas: 1
+      template:
+        spec:
+          parallelism: 2 # num node per node pool
+          completions: 2
+          backoffLimit: 0
+          template:
+            spec:
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 2x4
+              containers:
+              - name: jax-tpu
+                image: ubuntu
+                ports:
+                - containerPort: 8471
+                - containerPort: 8080
+                command:
+                - bash
+                - -c
+                - |
+                  sleep 1000
+                resources:
+                  limits:
+                    google.com/tpu: 4
+    - name: rs-bbb
+      replicas: 2
+      template:
+        spec:
+          parallelism: 1 # num node per node pool
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 2x2
+              containers:
+              - name: jax-tpu
+                image: ubuntu
+                ports:
+                - containerPort: 8471
+                - containerPort: 8080
+                command:
+                - bash
+                - -c
+                - |
+                  sleep 1000
+                resources:
+                  limits:
+                    google.com/tpu: 4

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -151,6 +151,11 @@ func (a *Aggregator) Aggregate(ctx context.Context) error {
 				return
 			}
 			up.ExpectedCount = expectedCount
+			if tpuChipCount, err := k8sutils.TpuTopologyToChipCount(up.TPUTopology); err != nil {
+				log.Printf("WARNING: failed to convert TPU topology to chip count for node pool %q: %v", np.Name, err)
+			} else {
+				up.TPUChipCount = int32(tpuChipCount)
+			}
 			report.NodePoolsUp[np.Name] = up
 		}()
 	}

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -108,6 +108,7 @@ func (a *Aggregator) Aggregate(ctx context.Context) error {
 
 	for _, js := range jobsetList.Items {
 		if !k8sutils.IsJobSetActive(&js) {
+			log.Printf("Skipping inactive jobset: %s", js.Name) // log at more verbose level later
 			continue
 		}
 

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -151,7 +151,7 @@ func (a *Aggregator) Aggregate(ctx context.Context) error {
 				return
 			}
 			up.ExpectedCount = expectedCount
-			if tpuChipCount, err := k8sutils.TpuTopologyToChipCount(up.TPUTopology); err != nil {
+			if tpuChipCount, err := k8sutils.GetTpuTopologyToChipCount(up.TPUTopology); err != nil {
 				log.Printf("WARNING: failed to convert TPU topology to chip count for node pool %q: %v", np.Name, err)
 			} else {
 				up.TPUChipCount = int32(tpuChipCount)

--- a/internal/aggregator/utils.go
+++ b/internal/aggregator/utils.go
@@ -30,6 +30,7 @@ func extractJobSetAttrs(js *jobset.JobSet) records.Attrs {
 			case k8sutils.NodeLabelGKETPUAccelerator:
 				attrs.TPUAccelerator = val
 			case k8sutils.NodeLabelGKETPUTopology:
+				attrs.TPUTopology = val
 				if topologyChipCount, err := k8sutils.TpuTopologyToChipCount(val); err == nil {
 					rjChipCount = topologyChipCount
 				} else {

--- a/internal/aggregator/utils.go
+++ b/internal/aggregator/utils.go
@@ -30,7 +30,7 @@ func extractJobSetAttrs(js *jobset.JobSet) records.Attrs {
 				attrs.TPUAccelerator = val
 			case k8sutils.NodeLabelGKETPUTopology:
 				attrs.TPUTopology = val
-				if topologyChipCount, err := k8sutils.TpuTopologyToChipCount(val); err == nil {
+				if topologyChipCount, err := k8sutils.GetTpuTopologyToChipCount(val); err == nil {
 					chipCount += rj.Replicas * int32(topologyChipCount)
 				} else {
 					// TODO: use controller-runtime logging

--- a/internal/aggregator/utils.go
+++ b/internal/aggregator/utils.go
@@ -30,12 +30,11 @@ func extractJobSetAttrs(js *jobset.JobSet) records.Attrs {
 			case k8sutils.NodeLabelGKETPUAccelerator:
 				attrs.TPUAccelerator = val
 			case k8sutils.NodeLabelGKETPUTopology:
-				attrs.TPUTopology = val
-				if topologyChipCount, err := k8sutils.TpuTopologyToChipCount(attrs.TPUTopology); err == nil {
+				if topologyChipCount, err := k8sutils.TpuTopologyToChipCount(val); err == nil {
 					rjChipCount = topologyChipCount
 				} else {
 					// TODO: use controller-runtime logging
-					log.Printf("error converting TPU topology (%s) to chip count: %v", attrs.TPUTopology, err)
+					log.Printf("error converting TPU topology (%s) to chip count: %v", val, err)
 				}
 			case k8sutils.NodeLabelGKESpot:
 				attrs.Spot = val == "true"

--- a/internal/aggregator/utils_test.go
+++ b/internal/aggregator/utils_test.go
@@ -5,7 +5,6 @@ import (
 
 	"example.com/megamon/internal/k8sutils"
 	"example.com/megamon/internal/records"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	containerv1beta1 "google.golang.org/api/container/v1beta1"
@@ -223,9 +222,7 @@ func TestExtractJobSetAttrs(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := extractJobSetAttrs(c.js)
-			if diff := cmp.Diff(c.want, got); diff != "" {
-				t.Errorf("extractJobSetAttrs() mismatch (-want +got):\n%s", diff)
-			}
+			require.Equal(t, c.want, got)
 		})
 	}
 }
@@ -272,9 +269,7 @@ func TestExtractNodeAttrs(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := extractNodeAttrs(c.node)
-			if diff := cmp.Diff(c.want, got); diff != "" {
-				t.Errorf("extractNodeAttrs() mismatch (-want +got):\n%s", diff)
-			}
+			require.Equal(t, c.want, got)
 		})
 	}
 }

--- a/internal/aggregator/utils_test.go
+++ b/internal/aggregator/utils_test.go
@@ -3,8 +3,16 @@ package aggregator
 import (
 	"testing"
 
+	"example.com/megamon/internal/k8sutils"
+	"example.com/megamon/internal/records"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+
 	containerv1beta1 "google.golang.org/api/container/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
 
 func TestGetExpectedTPUNodePoolSize(t *testing.T) {
@@ -71,6 +79,202 @@ func TestGetExpectedTPUNodePoolSize(t *testing.T) {
 				require.ErrorContains(t, err, c.wantErrContains)
 			}
 			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestExtractJobSetAttrs(t *testing.T) {
+	cases := map[string]struct {
+		js   *jobset.JobSet
+		want records.Attrs
+	}{
+		"empty": {
+			js:   &jobset.JobSet{},
+			want: records.Attrs{},
+		},
+		"basic": {
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobset",
+					Namespace: "test-ns",
+					UID:       "12345",
+				},
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Replicas: 1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											NodeSelector: map[string]string{
+												k8sutils.NodeLabelGKETPUAccelerator: "tpu-v5p",
+												k8sutils.NodeLabelGKETPUTopology:    "2x2x1",
+												k8sutils.NodeLabelGKESpot:           "true",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: records.Attrs{
+				JobSetName:      "test-jobset",
+				JobSetNamespace: "test-ns",
+				JobSetUID:       "12345",
+				TPUAccelerator:  "tpu-v5p",
+				TPUTopology:     "2x2x1",
+				Spot:            true,
+				TPUChipCount:    4,
+			},
+		},
+		"multiple replicated jobs": {
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobset",
+					Namespace: "test-ns",
+					UID:       "12345",
+				},
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Replicas: 1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											NodeSelector: map[string]string{
+												k8sutils.NodeLabelGKETPUAccelerator: "tpu-v5p",
+												k8sutils.NodeLabelGKETPUTopology:    "2x2x1",
+												k8sutils.NodeLabelGKESpot:           "false",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											NodeSelector: map[string]string{
+												k8sutils.NodeLabelGKETPUAccelerator: "tpu-v5p",
+												k8sutils.NodeLabelGKETPUTopology:    "2x4x1",
+												k8sutils.NodeLabelGKESpot:           "false",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: records.Attrs{
+				JobSetName:      "test-jobset",
+				JobSetNamespace: "test-ns",
+				JobSetUID:       "12345",
+				TPUAccelerator:  "tpu-v5p",
+				TPUTopology:     "2x4x1",
+				Spot:            false,
+				TPUChipCount:    20,
+			},
+		},
+		"missing topology": {
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobset",
+					Namespace: "test-ns",
+					UID:       "12345",
+				},
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Replicas: 1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											NodeSelector: map[string]string{
+												k8sutils.NodeLabelGKETPUAccelerator: "tpu-v5p",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: records.Attrs{
+				JobSetName:      "test-jobset",
+				JobSetNamespace: "test-ns",
+				JobSetUID:       "12345",
+				TPUAccelerator:  "tpu-v5p",
+				Spot:            false,
+				TPUChipCount:    0,
+			},
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := extractJobSetAttrs(c.js)
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Errorf("extractJobSetAttrs() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractNodeAttrs(t *testing.T) {
+	cases := map[string]struct {
+		node *corev1.Node
+		want records.Attrs
+	}{
+		"empty": {
+			node: &corev1.Node{},
+			want: records.Attrs{},
+		},
+		"basic": {
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						k8sutils.NodeLabelGKETPUAccelerator: "tpu-v5p",
+						k8sutils.NodeLabelGKETPUTopology:    "2x2x1",
+						k8sutils.NodeLabelGKESpot:           "true",
+					},
+				},
+			},
+			want: records.Attrs{
+				TPUAccelerator: "tpu-v5p",
+				TPUTopology:    "2x2x1",
+				Spot:           true,
+			},
+		},
+		"missing optional fields": {
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						k8sutils.NodeLabelGKETPUAccelerator: "tpu-v5p",
+					},
+				},
+			},
+			want: records.Attrs{
+				TPUAccelerator: "tpu-v5p",
+				Spot:           false,
+			},
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := extractNodeAttrs(c.node)
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Errorf("extractNodeAttrs() mismatch (-want +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/internal/k8sutils/utils.go
+++ b/internal/k8sutils/utils.go
@@ -141,3 +141,20 @@ func GetExpectedTPUNodePoolSize(node *corev1.Node) (int32, error) {
 
 	return int32(product / acceleratorCount), nil
 }
+
+func TpuTopologyToChipCount(topo string) (int, error) {
+	// TODO: Do we need to validate expectedDims? GKE won't run the jobset if this is invalid?
+	split := strings.Split(topo, "x")
+	if split == nil {
+		return 0, fmt.Errorf("invalid topology: %v", topo)
+	}
+	product := 1
+	for _, s := range split {
+		x, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid topology: %v, could not convert %q to int: %w", topo, s, err)
+		}
+		product *= x
+	}
+	return product, nil
+}

--- a/internal/k8sutils/utils.go
+++ b/internal/k8sutils/utils.go
@@ -126,27 +126,18 @@ func GetExpectedTPUNodePoolSize(node *corev1.Node) (int32, error) {
 		return 0, fmt.Errorf("invalid accelerator count: %d", acceleratorCount)
 	}
 
-	split := strings.Split(topoVal, "x")
-	if len(split) < 2 {
-		return 0, fmt.Errorf("invalid topology: %q", topoVal)
+	product, err := GetTpuTopologyToChipCount(topoVal)
+	if err != nil {
+		return 0, err
 	}
-	product := 1
-	for _, s := range split {
-		x, err := strconv.Atoi(s)
-		if err != nil {
-			return 0, fmt.Errorf("invalid topology: %q, could not convert %q to int: %w", topoVal, s, err)
-		}
-		product *= x
-	}
-
 	return int32(product / acceleratorCount), nil
 }
 
-func TpuTopologyToChipCount(topo string) (int, error) {
+func GetTpuTopologyToChipCount(topo string) (int, error) {
 	// TODO: Do we need to validate expectedDims? GKE won't run the jobset if this is invalid?
 	split := strings.Split(topo, "x")
-	if split == nil {
-		return 0, fmt.Errorf("invalid topology: %v", topo)
+	if len(split) < 2 {
+		return 0, fmt.Errorf("invalid topology: %q", topo)
 	}
 	product := 1
 	for _, s := range split {

--- a/internal/k8sutils/utils_test.go
+++ b/internal/k8sutils/utils_test.go
@@ -80,3 +80,60 @@ func TestGetExpectedTPUNodePoolSize(t *testing.T) {
 	}
 
 }
+
+func TestGetTpuTopologyToChipCount(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		topo            string
+		want            int
+		wantErrContains string
+	}{
+		"valid 2x2": {
+			topo: "2x2",
+			want: 4,
+		},
+		"valid 2x4": {
+			topo: "2x4",
+			want: 8,
+		},
+		"valid 4x2": {
+			topo: "4x2",
+			want: 8,
+		},
+		"valid 8x8x8": {
+			topo: "8x8x8",
+			want: 512,
+		},
+		"invalid empty": {
+			topo:            "",
+			wantErrContains: "invalid topology",
+		},
+		"invalid single": {
+			topo:            "2",
+			wantErrContains: "invalid topology",
+		},
+		"invalid 2x": {
+			topo:            "2x",
+			wantErrContains: "invalid topology",
+		},
+		"invalid x2": {
+			topo:            "x2",
+			wantErrContains: "invalid topology",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := k8sutils.GetTpuTopologyToChipCount(c.topo)
+			if c.wantErrContains != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -160,6 +160,11 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 	)
 	fatal(err)
 
+	npChipCount, err := meter.Int64ObservableGauge(prefix+".tpu.chip.count",
+		metric.WithDescription("Total number of TPU chips."),
+	)
+	fatal(err)
+
 	// NOTE: Gauges are used instead of Counters because Megamon restarts
 	// can show up as different timeseries if they are scraped using a scraper that
 	// adds a label for the megamon Pod name (when scraped via `kind: PodMonitoring` in
@@ -274,6 +279,9 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 			if summary.Attrs.JobSetName != "" && summary.TPUChipCount != 0 {
 				o.ObserveInt64(tpuChipCount, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
 			}
+			if summary.Attrs.NodePoolName != "" && summary.TPUChipCount != 0 {
+				o.ObserveInt64(npChipCount, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
+			}
 		}
 	}
 
@@ -291,6 +299,7 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 		interruptionCount,
 		recoveryCount,
 		tpuChipCount,
+		npChipCount,
 	}, observeFunc
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -229,7 +229,7 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 	)
 	fatal(err)
 
-	tpuChipCount, err := meter.Int64ObservableGauge(Prefix+".jobset.tpu.chip.count",
+	tpuChipCount, err := meter.Int64ObservableGauge(prefix+".tpu.chip.count",
 		metric.WithDescription("Total number of TPU chips."))
 	fatal(err)
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -82,9 +82,9 @@ func Init(ctx context.Context, r Reporter, interval time.Duration) func() {
 	)
 	fatal(err)
 
-	jobsetObservables, observeJobset := mustRegisterUpnessMetrics(Prefix+".jobset", meter)
-	jobsetNodeObservables, observeJobsetNodes := mustRegisterUpnessMetrics(Prefix+".jobset.nodes", meter)
-	nodePoolObservables, observeNodePools := mustRegisterUpnessMetrics(Prefix+".nodepool", meter)
+	jobsetObservables, observeJobset := mustRegisterUpnessMetrics(Prefix+".jobset", meter, false)
+	jobsetNodeObservables, observeJobsetNodes := mustRegisterUpnessMetrics(Prefix+".jobset.nodes", meter, false)
+	nodePoolObservables, observeNodePools := mustRegisterUpnessMetrics(Prefix+".nodepool", meter, true)
 
 	observables := append(jobsetObservables, jobsetNodeObservables...)
 	observables = append(observables, nodePoolObservables...)
@@ -136,9 +136,6 @@ func OTELAttrs(attrs records.Attrs) []attribute.KeyValue {
 	if attrs.JobSetUID != "" {
 		otelAttrs = append(otelAttrs, attribute.String("jobset.uid", attrs.JobSetUID))
 	}
-	if attrs.TPUTopology != "" {
-		otelAttrs = append(otelAttrs, attribute.String("tpu.topology", attrs.TPUTopology))
-	}
 	if attrs.TPUAccelerator != "" {
 		otelAttrs = append(otelAttrs, attribute.String("tpu.accelerator", attrs.TPUAccelerator))
 	}
@@ -154,7 +151,7 @@ func OTELAttrs(attrs records.Attrs) []attribute.KeyValue {
 type reportObserveFunc func(ctx context.Context, o metric.Observer, ups map[string]records.Upness, summaries map[string]records.UpnessSummaryWithAttrs)
 
 // mustRegisterUpnessMetrics registers a set of metrics for observing the upness of something.
-func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Observable, reportObserveFunc) {
+func mustRegisterUpnessMetrics(prefix string, meter metric.Meter, includeTPUTopology bool) ([]metric.Observable, reportObserveFunc) {
 	up, err := meter.Int64ObservableGauge(prefix+".up",
 		metric.WithDescription("Whether all replicas are in a Ready status (0 or 1)."),
 	)
@@ -246,6 +243,9 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 
 		for _, summary := range summaries {
 			commonAttrs := OTELAttrs(summary.Attrs)
+			if includeTPUTopology && summary.Attrs.TPUTopology != "" {
+				commonAttrs = append(commonAttrs, attribute.String("tpu.topology", summary.Attrs.TPUTopology))
+			}
 			o.ObserveInt64(interruptionCount, int64(summary.InterruptionCount), metric.WithAttributes(commonAttrs...))
 			o.ObserveInt64(recoveryCount, int64(summary.RecoveryCount), metric.WithAttributes(commonAttrs...))
 			o.ObserveFloat64(upTime, summary.UpTime.Seconds(), metric.WithAttributes(commonAttrs...))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -229,6 +229,10 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 	)
 	fatal(err)
 
+	tpuChipCountMeter, err := meter.Int64ObservableGauge(Prefix+".jobset.tpu.chip.count",
+		metric.WithDescription("Total number of TPU chips."))
+	fatal(err)
+
 	observeFunc := func(ctx context.Context, o metric.Observer, upnesses map[string]records.Upness, summaries map[string]records.UpnessSummaryWithAttrs) {
 		for _, upness := range upnesses {
 			val := int64(0)
@@ -267,6 +271,9 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 			if summary.LatestUpTimeBetweenInterruption != 0 {
 				o.ObserveFloat64(upTimeBetweenInterruptionLatest, summary.LatestUpTimeBetweenInterruption.Seconds(), metric.WithAttributes(commonAttrs...))
 			}
+			if summary.TPUChipCount != 0 {
+				o.ObserveInt64(tpuChipCountMeter, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
+			}
 		}
 	}
 
@@ -283,6 +290,7 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 		downTimeBetweenRecoveryLatest,
 		interruptionCount,
 		recoveryCount,
+		tpuChipCountMeter,
 	}, observeFunc
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -236,8 +236,12 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter, includeTPUTopo
 			if upness.Up() {
 				val = 1
 			}
+			upnessAttr := OTELAttrs(upness.Attrs)
+			if includeTPUTopology && upness.Attrs.TPUTopology != "" {
+				upnessAttr = append(upnessAttr, attribute.String("tpu.topology", upness.Attrs.TPUTopology))
+			}
 			o.ObserveInt64(up, val, metric.WithAttributes(
-				OTELAttrs(upness.Attrs)...,
+				upnessAttr...,
 			))
 		}
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -160,11 +160,6 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 	)
 	fatal(err)
 
-	npChipCount, err := meter.Int64ObservableGauge(prefix+".tpu.chip.count",
-		metric.WithDescription("Total number of TPU chips."),
-	)
-	fatal(err)
-
 	// NOTE: Gauges are used instead of Counters because Megamon restarts
 	// can show up as different timeseries if they are scraped using a scraper that
 	// adds a label for the megamon Pod name (when scraped via `kind: PodMonitoring` in
@@ -276,11 +271,8 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 			if summary.LatestUpTimeBetweenInterruption != 0 {
 				o.ObserveFloat64(upTimeBetweenInterruptionLatest, summary.LatestUpTimeBetweenInterruption.Seconds(), metric.WithAttributes(commonAttrs...))
 			}
-			if summary.Attrs.JobSetName != "" && summary.TPUChipCount != 0 {
+			if summary.TPUChipCount != 0 {
 				o.ObserveInt64(tpuChipCount, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
-			}
-			if summary.Attrs.NodePoolName != "" && summary.TPUChipCount != 0 {
-				o.ObserveInt64(npChipCount, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
 			}
 		}
 	}
@@ -299,7 +291,6 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 		interruptionCount,
 		recoveryCount,
 		tpuChipCount,
-		npChipCount,
 	}, observeFunc
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -229,7 +229,7 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 	)
 	fatal(err)
 
-	tpuChipCountMeter, err := meter.Int64ObservableGauge(Prefix+".jobset.tpu.chip.count",
+	tpuChipCount, err := meter.Int64ObservableGauge(Prefix+".jobset.tpu.chip.count",
 		metric.WithDescription("Total number of TPU chips."))
 	fatal(err)
 
@@ -239,9 +239,8 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 			if upness.Up() {
 				val = 1
 			}
-			upnessAttr := OTELAttrs(upness.Attrs)
 			o.ObserveInt64(up, val, metric.WithAttributes(
-				upnessAttr...,
+				OTELAttrs(upness.Attrs)...,
 			))
 		}
 
@@ -272,8 +271,8 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 			if summary.LatestUpTimeBetweenInterruption != 0 {
 				o.ObserveFloat64(upTimeBetweenInterruptionLatest, summary.LatestUpTimeBetweenInterruption.Seconds(), metric.WithAttributes(commonAttrs...))
 			}
-			if summary.TPUChipCount != 0 {
-				o.ObserveInt64(tpuChipCountMeter, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
+			if summary.Attrs.JobSetName != "" && summary.TPUChipCount != 0 {
+				o.ObserveInt64(tpuChipCount, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
 			}
 		}
 	}
@@ -291,7 +290,7 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter) ([]metric.Obse
 		downTimeBetweenRecoveryLatest,
 		interruptionCount,
 		recoveryCount,
-		tpuChipCountMeter,
+		tpuChipCount,
 	}, observeFunc
 }
 

--- a/internal/records/report.go
+++ b/internal/records/report.go
@@ -28,6 +28,7 @@ type Attrs struct {
 
 	TPUTopology    string `json:"tpuTopology"`
 	TPUAccelerator string `json:"tpuAccelerator"`
+	TPUChipCount   int32  `json:"tpuChipCount"`
 	Spot           bool   `json:"spot"`
 
 	NodePoolName string `json:"nodePoolName"`

--- a/test/integration/cases_test.go
+++ b/test/integration/cases_test.go
@@ -187,6 +187,7 @@ var _ = Describe("Nodepool metrics", func() {
 				nodepool.recovery_count.WithValue(0),
 				nodepool.up.WithValue(0),
 				nodepool.up_time_seconds.WithValue(0),
+				nodepool.tpu_chip_count.WithValue(256),
 			)
 		})
 
@@ -382,6 +383,7 @@ type utilizationMetrics struct {
 	recovery_count     metric
 	up                 metric
 	up_time_seconds    metric
+	tpu_chip_count     metric
 
 	// Present after events occur
 	job_scheduled metric
@@ -420,6 +422,10 @@ func expectedMetricsForNodePool(np *containerv1beta1.NodePool, jobSetName string
 		},
 		up_time_seconds: metric{
 			name:   "nodepool_up_time_seconds",
+			labels: nodepoolLabels,
+		},
+		tpu_chip_count: metric{
+			name:   "nodepool_tpu_chip_count",
 			labels: nodepoolLabels,
 		},
 	}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -65,8 +65,8 @@ var testCfg = manager.Config{
 	AggregationIntervalSeconds: 1,
 	EventsBucketName:           "test-bucket",
 	EventsBucketPath:           "test-path",
-	MetricsAddr:                "127.0.0.1:8080",
-	ProbeAddr:                  "127.0.0.1:8081",
+	MetricsAddr:                "127.0.0.1:28080",
+	ProbeAddr:                  "127.0.0.1:28081",
 }
 
 func TestControllers(t *testing.T) {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -77,7 +77,7 @@ func TestControllers(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	format.MaxLength = 20000 // Gomega default is 4000, anything past "MaxLength" will get truncateed in output
+	format.MaxLength = 30000 // Gomega default is 4000, anything past "MaxLength" will get truncateed in output
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -36,7 +36,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	// +kubebuilder:scaffold:imports
+	"github.com/onsi/gomega/format"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,6 +77,7 @@ func TestControllers(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	format.MaxLength = 20000
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -77,7 +77,7 @@ func TestControllers(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	format.MaxLength = 20000
+	format.MaxLength = 20000 // Gomega default is 4000, anything past "MaxLength" will get truncateed in output
 
 	ctx, cancel = context.WithCancel(context.TODO())
 


### PR DESCRIPTION
Add in TPU chip count

example output:
```
megamon_alpha_jobset_tpu_chip_count{jobset_name="ex-multi-2rj-20-nonspot",jobset_namespace="default",jobset_uid="0833141e-8b2e-4b36-902b-5cc9930adad1",otel_scope_name="megamon",otel_scope_version="",tpu_accelerator="tpu-v5-lite-podslice"} 20
```

Two new test jobsets to validate:
 * example-tpu-jobset-2rj-20-nonspot.yaml
   * 2 replicated jobs of differing topologies 
 * example-tpu-jobset-r2-16.yaml
   * replicated job with > 1 replica
