### PR TITLE
Use controller-runtime log package

### DIFF
--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -3,7 +3,6 @@ package aggregator
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +13,7 @@ import (
 	containerv1beta1 "google.golang.org/api/container/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
 
@@ -38,6 +38,8 @@ type Aggregator struct {
 	GKE GKEClient
 	GCS GCSClient
 }
+
+var log = logf.Log.WithName("aggregator")
 
 type GKEClient interface {
 	ListNodePools(ctx context.Context) ([]*containerv1beta1.NodePool, error)
@@ -66,19 +68,19 @@ func (a *Aggregator) Start(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-t.C:
-			log.Println("aggregating")
+			log.Info("aggregating")
 		}
 
 		start := time.Now()
 		if err := a.Aggregate(ctx); err != nil {
-			log.Printf("failed to aggregate: %v", err)
+			log.Error(err, "failed to aggregate")
 			continue
 		}
 		metrics.AggregationDuration.Record(ctx, time.Since(start).Seconds())
 
 		for name, exporter := range a.Exporters {
 			if err := exporter.Export(ctx, a.Report()); err != nil {
-				log.Printf("failed to export %s: %v", name, err)
+				log.Error(err, "failed to export", "exporter", name)
 			}
 		}
 	}
@@ -146,7 +148,7 @@ func (a *Aggregator) Aggregate(ctx context.Context) error {
 			}
 			expectedCount, err := getExpectedTPUNodePoolSize(np)
 			if err != nil {
-				log.Printf("ERROR: failed to get expected TPU node pool size for node pool %q: %v", np.Name, err)
+				log.Error(err, "failed to get expected TPU node pool size", "nodepool", np.Name)
 				return
 			}
 			up.ExpectedCount = expectedCount
@@ -166,14 +168,14 @@ func (a *Aggregator) Aggregate(ctx context.Context) error {
 				}
 				up, ok := report.NodePoolsUp[npName]
 				if !ok {
-					log.Printf("WARNING: found Node (%q) for node pool (%q) that was not parsed", node.Name, npName)
+					log.Info("WARNING: found Node for node pool that was not parsed", "node", node.Name, "nodepool", npName)
 					return
 				}
 				if up.ExpectedCount == 0 {
 					var err error
 					up.ExpectedCount, err = k8sutils.GetExpectedTPUNodePoolSize(&node)
 					if err != nil {
-						log.Printf("failed to get expected TPU node pool size for node %q: %v", node.Name, err)
+						log.Error(err, "failed to get expected TPU node pool size", "node", node.Name)
 						return
 					}
 				}

--- a/internal/controller/jobset_reconciler.go
+++ b/internal/controller/jobset_reconciler.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
 
@@ -22,8 +21,6 @@ type JobSetReconciler struct {
 // +kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets/status,verbs=get
 
 func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
-
 	if r.Disabled {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/pod_reconciler.go
+++ b/internal/controller/pod_reconciler.go
@@ -12,7 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var log = logf.Log.WithName("controller")
 
 const (
 	jobScheduledNodePoolLabel = "megamon.tbd/scheduled-node-pool"
@@ -37,6 +40,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	log.V(5).Info("PodReconciler pod", "pod", pod)
 
 	// Example labels:
 	//   batch.kubernetes.io/job-name: example-single-3-rs-s-0

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"sync"
@@ -187,6 +186,8 @@ type GCSClient interface {
 
 func MustRun(ctx context.Context, cfg Config, restConfig *rest.Config, gkeClient GKEClient, gcsClient GCSClient) {
 	metrics.Prefix = cfg.MetricsPrefix
+
+	setupLog.V(1).Info("starting manager with config", "cfg", cfg)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -414,7 +415,7 @@ func MustRun(ctx context.Context, cfg Config, restConfig *rest.Config, gkeClient
 
 	wg.Add(1)
 	go func() {
-		log.Println("starting metrics server")
+		setupLog.Info("starting metrics server")
 		defer wg.Done()
 		if err := metricsServer.ListenAndServe(); err != nil {
 			if errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
Continuing work from @echiugoog to use the controller-runtime logging package instead of Go's log package