### PR TITLE
feat: add nodepool_provisioning_duration metric

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## v1.1.1
 
 ### New features and improvements
-* Add `nodepool.provisioning.duration` metric to track GKE NodePool provisioning latency with state tracking (`provisioning`, `success`, `failed`).
+* Add `nodepool.provisioning.duration` metric to track GKE NodePool provisioning latency with state tracking (`provisioning`, `success`, `failed`). See [docs/metrics.md](metrics.md) for details.
 
 ## v1.1.0
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v1.1.1
+
+### New features and improvements
+* Add `nodepool.provisioning.duration` metric to track GKE NodePool provisioning latency with state tracking (`provisioning`, `success`, `failed`).
+
 ## v1.1.0
 
 ### New features and improvements

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## v1.1.1
 
 ### New features and improvements
-* Add `nodepool.provisioning.duration` metric to track GKE NodePool provisioning latency with state tracking (`provisioning`, `success`, `failed`). See [docs/metrics.md](metrics.md) for details.
+* Add standardized `<resource>.provisioning.duration` metric family (e.g. `nodepool.provisioning.duration`, `jobset.provisioning.duration`) to track resource provisioning latency with state tracking (`provisioning`, `success`, `failed`). See [docs/metrics.md](metrics.md) for details.
 
 ## v1.1.0
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,23 +1,25 @@
 # Metrics
 
-## Nodepool Metrics
+## Provisioning Metrics
 
-### `megamon.nodepool.provisioning.duration`
+### `<resource>.provisioning.duration`
+
+Megamon emits a standardized provisioning duration metric for managed resources (e.g. `megamon.nodepool.provisioning.duration`, `megamon.jobset.provisioning.duration`, `megamon.slice.provisioning.duration`).
 
 *   **Introduced in**: `v1.1.1`
 *   **Type**: Gauge
 *   **Unit**: Seconds (s)
-*   **Description**: Time spent provisioning a GKE NodePool.
+*   **Description**: Time spent provisioning a resource (GKE NodePool, JobSet, Slice).
 *   **Labels**:
-    *   `nodepool_name`: The name of the NodePool.
-    *   `tpu_accelerator`: The type of TPU accelerator (e.g., `tpu-v4-podslice`).
-    *   `tpu_topology`: The TPU topology (e.g., `2x2x1`).
     *   `provisioning_state`: The state of provisioning. Possible values:
-        *   `provisioning`: The NodePool is currently being provisioned. The value represents the time elapsed since provisioning started.
-        *   `success`: The NodePool has successfully become ready. The value represents the total time taken to become ready.
-        *   `failed`: The NodePool provisioning failed. The value represents the time elapsed until failure.
+        *   `provisioning`: The resource is currently being provisioned. The value represents the time elapsed since provisioning started.
+        *   `success`: The resource has successfully become ready. The value represents the total time taken to become ready.
+        *   `failed`: The resource provisioning failed. The value represents the time elapsed until failure.
+    *   Standard resource labels (e.g. `nodepool_name`, `jobset_name`, `tpu_accelerator`, `tpu_topology`, etc.).
 
 #### Examples
+
+##### 1. NodePool Metrics
 
 **Resource still provisioning:**
 ```
@@ -32,4 +34,16 @@ megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-poo
 **Resource failed provisioning:**
 ```
 megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-pool", provisioning_state="failed", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 120.045
+```
+
+##### 2. JobSet Metrics
+
+**JobSet provisioning (in-flight):**
+```
+megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="train-job", jobset_namespace="default", jobset_uid="abc-123", provisioning_state="provisioning", tpu_topology="2x2x1"} 32.504
+```
+
+**JobSet successfully ready:**
+```
+megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="train-job", jobset_namespace="default", jobset_uid="abc-123", provisioning_state="success", tpu_topology="2x2x1"} 85.120
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,34 @@
+# Metrics
+
+## Nodepool Metrics
+
+### `megamon.nodepool.provisioning.duration`
+
+*   **Type**: Gauge
+*   **Unit**: Seconds (s)
+*   **Description**: Time spent provisioning a GKE NodePool.
+*   **Labels**:
+    *   `nodepool_name`: The name of the NodePool.
+    *   `tpu_accelerator`: The type of TPU accelerator (e.g., `tpu-v4-podslice`).
+    *   `tpu_topology`: The TPU topology (e.g., `2x2x1`).
+    *   `provisioning_state`: The state of provisioning. Possible values:
+        *   `provisioning`: The NodePool is currently being provisioned. The value represents the time elapsed since provisioning started.
+        *   `success`: The NodePool has successfully become ready. The value represents the total time taken to become ready.
+        *   `failed`: The NodePool provisioning failed. The value represents the time elapsed until failure.
+
+#### Examples
+
+**Resource still provisioning:**
+```
+megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-pool", provisioning_state="provisioning", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 45.123
+```
+
+**Resource successfully provisioned:**
+```
+megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-pool", provisioning_state="success", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 190.008
+```
+
+**Resource failed provisioning:**
+```
+megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-pool", provisioning_state="failed", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 120.045
+```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,6 +4,7 @@
 
 ### `megamon.nodepool.provisioning.duration`
 
+*   **Introduced in**: `v1.1.1`
 *   **Type**: Gauge
 *   **Unit**: Seconds (s)
 *   **Description**: Time spent provisioning a GKE NodePool.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -12,38 +12,55 @@ Megamon emits a standardized provisioning duration metric for managed resources 
 *   **Description**: Time spent provisioning a resource (GKE NodePool, JobSet, Slice).
 *   **Labels**:
     *   `provisioning_state`: The state of provisioning. Possible values:
-        *   `provisioning`: The resource is currently being provisioned. The value represents the time elapsed since provisioning started.
+        *   `provisioning`: The resource is currently being provisioned. The value represents the elapsed time since provisioning started and increases every aggregation cycle.
         *   `success`: The resource has successfully become ready. The value represents the total time taken to become ready.
         *   `failed`: The resource provisioning failed. The value represents the time elapsed until failure.
-    *   Standard resource labels (e.g. `nodepool_name`, `jobset_name`, `tpu_accelerator`, `tpu_topology`, etc.).
+    *   Standard resource labels (`nodepool_name`, `jobset_name`, `tpu_accelerator`, `tpu_topology`, etc.).
 
-#### Examples
+#### Alerting Use Case
+
+Because `provisioning_state="provisioning"` steadily increases while a resource is in-flight, you can create proactive alerts for stuck provisioning workflows:
+
+```promql
+# Alert if any NodePool has been stuck in provisioning for more than 30 minutes
+megamon_nodepool_provisioning_duration_seconds{provisioning_state="provisioning"} > 1800
+
+# Alert if any JobSet has been stuck in provisioning for more than 15 minutes
+megamon_jobset_provisioning_duration_seconds{provisioning_state="provisioning"} > 900
+```
+
+#### Scrape Examples
 
 ##### 1. NodePool Metrics
 
 **Resource still provisioning:**
 ```
-megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-pool", provisioning_state="provisioning", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 45.123
+megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-validation-pool-1763155065", provisioning_state="provisioning", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 45.123
 ```
 
 **Resource successfully provisioned:**
 ```
-megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-pool", provisioning_state="success", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 190.008
+megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-validation-pool-1763155065", provisioning_state="success", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 160.010
 ```
 
 **Resource failed provisioning:**
 ```
-megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-test-pool", provisioning_state="failed", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 120.045
+megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-validation-pool-1763155065", provisioning_state="failed", tpu_accelerator="tpu-v4-podslice", tpu_topology="2x2x1"} 120.045
 ```
 
 ##### 2. JobSet Metrics
 
 **JobSet provisioning (in-flight):**
 ```
-megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="train-job", jobset_namespace="default", jobset_uid="abc-123", provisioning_state="provisioning", tpu_topology="2x2x1"} 32.504
+megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="tpu-jobset-validation", jobset_namespace="default", jobset_uid="452a4983-6cbb-494a-bd9e-93ebac89581a", provisioning_state="provisioning", tpu_topology="2x2x1"} 5.210
 ```
 
 **JobSet successfully ready:**
 ```
-megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="train-job", jobset_namespace="default", jobset_uid="abc-123", provisioning_state="success", tpu_topology="2x2x1"} 85.120
+megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="tpu-jobset-validation", jobset_namespace="default", jobset_uid="452a4983-6cbb-494a-bd9e-93ebac89581a", provisioning_state="success", tpu_topology="2x2x1"} 18.415
+```
+
+**JobSet failed provisioning:**
+```
+megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="tpu-jobset-failed-test", jobset_namespace="default", jobset_uid="c146a977-95b2-4cf4-bbb7-d10ad7ba9798", provisioning_state="failed", tpu_topology="2x2x1"} 70.287
 ```

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
 	sigs.k8s.io/controller-runtime v0.22.4
 	sigs.k8s.io/jobset v0.6.0
+	sigs.k8s.io/lws v0.8.0
 )
 
 require (
@@ -129,7 +130,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
-	sigs.k8s.io/lws v0.8.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/internal/aggregator/poller/node_poller.go
+++ b/internal/aggregator/poller/node_poller.go
@@ -17,6 +17,13 @@ import (
 
 var log = logf.Log.WithName("upness")
 
+const (
+	statusStopping         = "STOPPING"
+	statusDeleting         = "DELETING"
+	statusError            = "ERROR"
+	statusRunningWithError = "RUNNING_WITH_ERROR"
+)
+
 type GKEClient interface {
 	ListNodePools(ctx context.Context) ([]*containerv1beta1.NodePool, error)
 }
@@ -52,8 +59,8 @@ func (p *NodePoller) PollResources(ctx context.Context) (map[string]records.Upne
 			up := records.Upness{
 				Attrs:        utils.ExtractNodePoolAttrs(np),
 				Status:       np.Status,
-				ExpectedDown: np.Status == "STOPPING" || np.Status == "DELETING",
-				Failed:       np.Status == "ERROR" || np.Status == "RUNNING_WITH_ERROR",
+				ExpectedDown: np.Status == statusStopping || np.Status == statusDeleting,
+				Failed:       np.Status == statusError || np.Status == statusRunningWithError,
 			}
 			expectedCount, err := utils.GetExpectedTPUNodePoolSize(np)
 			if err != nil {

--- a/internal/aggregator/poller/node_poller.go
+++ b/internal/aggregator/poller/node_poller.go
@@ -53,6 +53,7 @@ func (p *NodePoller) PollResources(ctx context.Context) (map[string]records.Upne
 				Attrs:        utils.ExtractNodePoolAttrs(np),
 				Status:       np.Status,
 				ExpectedDown: np.Status == "STOPPING" || np.Status == "DELETING",
+				Failed:       np.Status == "ERROR" || np.Status == "RUNNING_WITH_ERROR",
 			}
 			expectedCount, err := utils.GetExpectedTPUNodePoolSize(np)
 			if err != nil {

--- a/internal/aggregator/poller/node_poller_test.go
+++ b/internal/aggregator/poller/node_poller_test.go
@@ -39,22 +39,22 @@ func TestPollResources(t *testing.T) {
 			expectedFail: false,
 		},
 		"status stopping": {
-			status:       "STOPPING",
+			status:       statusStopping,
 			expectedDown: true,
 			expectedFail: false,
 		},
 		"status deleting": {
-			status:       "DELETING",
+			status:       statusDeleting,
 			expectedDown: true,
 			expectedFail: false,
 		},
 		"status error": {
-			status:       "ERROR",
+			status:       statusError,
 			expectedDown: false,
 			expectedFail: true,
 		},
 		"status running with error": {
-			status:       "RUNNING_WITH_ERROR",
+			status:       statusRunningWithError,
 			expectedDown: false,
 			expectedFail: true,
 		},

--- a/internal/aggregator/poller/node_poller_test.go
+++ b/internal/aggregator/poller/node_poller_test.go
@@ -28,14 +28,67 @@ func TestPollResources(t *testing.T) {
 	_ = jobset.AddToScheme(scheme)
 	_ = slice.AddToScheme(scheme)
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	fakeGKE := &fakeGKEClient{
-		nodePools: []*containerv1beta1.NodePool{},
+	tests := map[string]struct {
+		status       string
+		expectedDown bool
+		expectedFail bool
+	}{
+		"status running": {
+			status:       "RUNNING",
+			expectedDown: false,
+			expectedFail: false,
+		},
+		"status stopping": {
+			status:       "STOPPING",
+			expectedDown: true,
+			expectedFail: false,
+		},
+		"status deleting": {
+			status:       "DELETING",
+			expectedDown: true,
+			expectedFail: false,
+		},
+		"status error": {
+			status:       "ERROR",
+			expectedDown: false,
+			expectedFail: true,
+		},
+		"status running with error": {
+			status:       "RUNNING_WITH_ERROR",
+			expectedDown: false,
+			expectedFail: true,
+		},
 	}
 
-	provider := NewNodePoller(fakeClient, fakeGKE)
-	nodePoolsUp, err := provider.PollResources(context.Background())
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			fakeGKE := &fakeGKEClient{
+				nodePools: []*containerv1beta1.NodePool{
+					{
+						Name:   "test-tpu-pool",
+						Status: tc.status,
+						PlacementPolicy: &containerv1beta1.PlacementPolicy{
+							TpuTopology: "2x2x1",
+						},
+						Config: &containerv1beta1.NodeConfig{
+							MachineType: "ct4p-hightpu-4t",
+						},
+					},
+				},
+			}
 
-	require.NoError(t, err)
-	require.NotNil(t, nodePoolsUp)
+			provider := NewNodePoller(fakeClient, fakeGKE)
+			nodePoolsUp, err := provider.PollResources(context.Background())
+
+			require.NoError(t, err)
+			require.NotNil(t, nodePoolsUp)
+			require.Contains(t, nodePoolsUp, "test-tpu-pool")
+
+			upRecord := nodePoolsUp["test-tpu-pool"]
+			require.Equal(t, tc.expectedDown, upRecord.ExpectedDown, "ExpectedDown mismatch")
+			require.Equal(t, tc.expectedFail, upRecord.Failed, "Failed mismatch")
+			require.Equal(t, tc.status, upRecord.Status, "Status mismatch")
+		})
+	}
 }

--- a/internal/controller/workload_reconciler.go
+++ b/internal/controller/workload_reconciler.go
@@ -158,6 +158,7 @@ func (r *WorkloadReconciler) processJobSets(jobsetList jobset.JobSetList, nodeLi
 		specReplicas, readyReplicas := k8sutils.GetJobSetReplicas(&js)
 		state, isTerminal := k8sutils.GetJobSetTerminalState(&js)
 		expectedDown := isTerminal && state == jobset.JobSetCompleted
+		failed := isTerminal && state == jobset.JobSetFailed
 
 		jobsetsUp[jobsetUid] = records.Upness{
 			ExpectedCount: specReplicas,
@@ -165,6 +166,7 @@ func (r *WorkloadReconciler) processJobSets(jobsetList jobset.JobSetList, nodeLi
 			Attrs:         attrs,
 			Status:        string(state),
 			ExpectedDown:  expectedDown,
+			Failed:        failed,
 		}
 
 		if !r.SliceEnabled {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -110,6 +110,12 @@ func Init(ctx context.Context, r Reporter, interval time.Duration, unknownThresh
 	)
 	fatal(err)
 
+	provisioningDuration, err := meter.Float64ObservableGauge(Prefix+".nodepool.provisioning.duration",
+		metric.WithDescription("Time spent provisioning."),
+		metric.WithUnit("s"),
+	)
+	fatal(err)
+
 	jobsetObservables, observeJobset := mustRegisterUpnessMetrics(Prefix+".jobset", meter, unknownThreshold)
 	var jobsetNodeObservables []metric.Observable
 	var observeJobsetNodes reportObserveFunc
@@ -133,6 +139,7 @@ func Init(ctx context.Context, r Reporter, interval time.Duration, unknownThresh
 	}
 	observables = append(observables, nodePoolJobScheduled)
 	observables = append(observables, buildInfo)
+	observables = append(observables, provisioningDuration)
 
 	_, err = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
 		// Emit build info (always 1, attributes carry the data)
@@ -153,6 +160,15 @@ func Init(ctx context.Context, r Reporter, interval time.Duration, unknownThresh
 			observeJobsetNodes(ctx, o, report.JobSetNodesUp, report.JobSetNodesUpSummaries)
 		}
 		observeNodePools(ctx, o, report.NodePoolsUp, report.NodePoolsUpSummaries)
+
+		// Emit nodepool provisioning duration
+		for _, summary := range report.NodePoolsUpSummaries {
+			if summary.ProvisioningState != "" {
+				attrs := append(OTELAttrs(summary.Attrs), attribute.String("provisioning_state", summary.ProvisioningState))
+				o.ObserveFloat64(provisioningDuration, summary.ProvisioningDuration.Seconds(), metric.WithAttributes(attrs...))
+			}
+		}
+
 		if sliceEnabled {
 			observeSlices(ctx, o, report.SlicesUp, report.SlicesUpSummaries)
 		}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -110,12 +110,6 @@ func Init(ctx context.Context, r Reporter, interval time.Duration, unknownThresh
 	)
 	fatal(err)
 
-	provisioningDuration, err := meter.Float64ObservableGauge(Prefix+".nodepool.provisioning.duration",
-		metric.WithDescription("Time spent provisioning."),
-		metric.WithUnit("s"),
-	)
-	fatal(err)
-
 	jobsetObservables, observeJobset := mustRegisterUpnessMetrics(Prefix+".jobset", meter, unknownThreshold)
 	var jobsetNodeObservables []metric.Observable
 	var observeJobsetNodes reportObserveFunc
@@ -139,7 +133,6 @@ func Init(ctx context.Context, r Reporter, interval time.Duration, unknownThresh
 	}
 	observables = append(observables, nodePoolJobScheduled)
 	observables = append(observables, buildInfo)
-	observables = append(observables, provisioningDuration)
 
 	_, err = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
 		// Emit build info (always 1, attributes carry the data)
@@ -160,14 +153,6 @@ func Init(ctx context.Context, r Reporter, interval time.Duration, unknownThresh
 			observeJobsetNodes(ctx, o, report.JobSetNodesUp, report.JobSetNodesUpSummaries)
 		}
 		observeNodePools(ctx, o, report.NodePoolsUp, report.NodePoolsUpSummaries)
-
-		// Emit nodepool provisioning duration
-		for _, summary := range report.NodePoolsUpSummaries {
-			if summary.ProvisioningState != "" {
-				attrs := append(OTELAttrs(summary.Attrs), attribute.String("provisioning_state", summary.ProvisioningState))
-				o.ObserveFloat64(provisioningDuration, summary.ProvisioningDuration.Seconds(), metric.WithAttributes(attrs...))
-			}
-		}
 
 		if sliceEnabled {
 			observeSlices(ctx, o, report.SlicesUp, report.SlicesUpSummaries)
@@ -278,6 +263,12 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter, unknownThresho
 	)
 	fatal(err)
 
+	provisioningDuration, err := meter.Float64ObservableGauge(prefix+".provisioning.duration",
+		metric.WithDescription("Time spent provisioning."),
+		metric.WithUnit("s"),
+	)
+	fatal(err)
+
 	downTimeBetweenRecovery, err := meter.Float64ObservableGauge(prefix+".down.time.between.recovery",
 		metric.WithDescription("Total time spent down between being all interruptions and recoveries."),
 		metric.WithUnit("s"),
@@ -359,6 +350,10 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter, unknownThresho
 			if summary.TPUChipCount != 0 {
 				o.ObserveInt64(tpuChipCount, int64(summary.TPUChipCount), metric.WithAttributes(commonAttrs...))
 			}
+			if summary.ProvisioningState != "" {
+				attrs := append(commonAttrs, attribute.String("provisioning_state", summary.ProvisioningState))
+				o.ObserveFloat64(provisioningDuration, summary.ProvisioningDuration.Seconds(), metric.WithAttributes(attrs...))
+			}
 		}
 	}
 
@@ -376,6 +371,7 @@ func mustRegisterUpnessMetrics(prefix string, meter metric.Meter, unknownThresho
 		interruptionCount,
 		recoveryCount,
 		tpuChipCount,
+		provisioningDuration,
 	}, observeFunc
 }
 

--- a/internal/records/events.go
+++ b/internal/records/events.go
@@ -55,6 +55,11 @@ type EventSummary struct {
 	MeanDownTimeBetweenRecovery time.Duration `json:"meanDownTimeBetweenRecovery"`
 	// MeanUpTimeBetweenInterruption - Mean Time Between Interruption
 	MeanUpTimeBetweenInterruption time.Duration `json:"meanUpTimeBetweenInterruption"`
+
+	// ProvisioningDuration is the time spent provisioning.
+	ProvisioningDuration time.Duration `json:"provisioningDuration"`
+	// ProvisioningState is the state of provisioning (provisioning or success).
+	ProvisioningState string `json:"provisioningState"`
 }
 
 func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummary {
@@ -73,6 +78,8 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 	}
 	if n == 1 {
 		summary.DownTime = now.Sub(r.UpEvents[0].Timestamp)
+		summary.ProvisioningDuration = summary.DownTime
+		summary.ProvisioningState = "provisioning"
 		return summary
 	}
 	// Invalid or missing data:
@@ -83,6 +90,8 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 
 	summary.DownTime = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 	summary.DownTimeInitial = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
+	summary.ProvisioningDuration = summary.DownTimeInitial
+	summary.ProvisioningState = "success"
 
 	// up:        ___
 	// down:  ____|

--- a/internal/records/events.go
+++ b/internal/records/events.go
@@ -18,9 +18,9 @@ type EventRecords struct {
 }
 
 const (
-	NodepoolProvisioningStateProvisioning = "provisioning"
-	NodepoolProvisioningStateSuccess      = "success"
-	NodepoolProvisioningStateFailed       = "failed"
+	ProvisioningStateProvisioning = "provisioning"
+	ProvisioningStateSuccess      = "success"
+	ProvisioningStateFailed       = "failed"
 )
 
 type UpEvent struct {
@@ -86,7 +86,7 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 	if n == 1 {
 		summary.DownTime = now.Sub(r.UpEvents[0].Timestamp)
 		summary.ProvisioningDuration = summary.DownTime
-		summary.ProvisioningState = NodepoolProvisioningStateProvisioning
+		summary.ProvisioningState = ProvisioningStateProvisioning
 		return summary
 	}
 	// Invalid or missing data:
@@ -95,7 +95,7 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 			summary.DownTime = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 			summary.DownTimeInitial = summary.DownTime
 			summary.ProvisioningDuration = summary.DownTimeInitial
-			summary.ProvisioningState = NodepoolProvisioningStateFailed
+			summary.ProvisioningState = ProvisioningStateFailed
 			return summary
 		}
 		log.V(3).Info("invalid data: second event is not up and not failed")
@@ -105,7 +105,7 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 	summary.DownTime = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 	summary.DownTimeInitial = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 	summary.ProvisioningDuration = summary.DownTimeInitial
-	summary.ProvisioningState = NodepoolProvisioningStateSuccess
+	summary.ProvisioningState = ProvisioningStateSuccess
 
 	// up:        ___
 	// down:  ____|

--- a/internal/records/events.go
+++ b/internal/records/events.go
@@ -18,9 +18,9 @@ type EventRecords struct {
 }
 
 const (
-	StateProvisioning = "provisioning"
-	StateSuccess      = "success"
-	StateFailed       = "failed"
+	NodepoolProvisioningStateProvisioning = "provisioning"
+	NodepoolProvisioningStateSuccess      = "success"
+	NodepoolProvisioningStateFailed       = "failed"
 )
 
 type UpEvent struct {
@@ -65,7 +65,7 @@ type EventSummary struct {
 
 	// ProvisioningDuration is the time spent provisioning.
 	ProvisioningDuration time.Duration `json:"provisioningDuration"`
-	// ProvisioningState is the state of provisioning (provisioning or success).
+	// ProvisioningState is the state of provisioning.
 	ProvisioningState string `json:"provisioningState"`
 }
 
@@ -86,7 +86,7 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 	if n == 1 {
 		summary.DownTime = now.Sub(r.UpEvents[0].Timestamp)
 		summary.ProvisioningDuration = summary.DownTime
-		summary.ProvisioningState = StateProvisioning
+		summary.ProvisioningState = NodepoolProvisioningStateProvisioning
 		return summary
 	}
 	// Invalid or missing data:
@@ -95,7 +95,7 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 			summary.DownTime = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 			summary.DownTimeInitial = summary.DownTime
 			summary.ProvisioningDuration = summary.DownTimeInitial
-			summary.ProvisioningState = StateFailed
+			summary.ProvisioningState = NodepoolProvisioningStateFailed
 			return summary
 		}
 		log.V(3).Info("invalid data: second event is not up and not failed")
@@ -105,7 +105,7 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 	summary.DownTime = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 	summary.DownTimeInitial = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 	summary.ProvisioningDuration = summary.DownTimeInitial
-	summary.ProvisioningState = StateSuccess
+	summary.ProvisioningState = NodepoolProvisioningStateSuccess
 
 	// up:        ___
 	// down:  ____|

--- a/internal/records/events.go
+++ b/internal/records/events.go
@@ -17,9 +17,16 @@ type EventRecords struct {
 	UpEvents []UpEvent `json:"upEvents"`
 }
 
+const (
+	StateProvisioning = "provisioning"
+	StateSuccess      = "success"
+	StateFailed       = "failed"
+)
+
 type UpEvent struct {
 	Up           bool      `json:"up"`
 	ExpectedDown bool      `json:"ed,omitempty"`
+	Failed       bool      `json:"f,omitempty"`
 	Timestamp    time.Time `json:"ts"`
 }
 
@@ -79,19 +86,26 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 	if n == 1 {
 		summary.DownTime = now.Sub(r.UpEvents[0].Timestamp)
 		summary.ProvisioningDuration = summary.DownTime
-		summary.ProvisioningState = "provisioning"
+		summary.ProvisioningState = StateProvisioning
 		return summary
 	}
 	// Invalid or missing data:
 	if !r.UpEvents[1].Up {
-		log.V(3).Info("invalid data: second event is not up")
+		if r.UpEvents[1].Failed {
+			summary.DownTime = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
+			summary.DownTimeInitial = summary.DownTime
+			summary.ProvisioningDuration = summary.DownTimeInitial
+			summary.ProvisioningState = StateFailed
+			return summary
+		}
+		log.V(3).Info("invalid data: second event is not up and not failed")
 		return summary
 	}
 
 	summary.DownTime = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 	summary.DownTimeInitial = r.UpEvents[1].Timestamp.Sub(r.UpEvents[0].Timestamp)
 	summary.ProvisioningDuration = summary.DownTimeInitial
-	summary.ProvisioningState = "success"
+	summary.ProvisioningState = StateSuccess
 
 	// up:        ___
 	// down:  ____|
@@ -159,22 +173,24 @@ func (r *EventRecords) Summarize(ctx context.Context, now time.Time) EventSummar
 	return summary
 }
 
-func AppendUpEvent(now time.Time, rec *EventRecords, isUp bool, expectedDown bool) bool {
+func AppendUpEvent(now time.Time, rec *EventRecords, isUp bool, expectedDown bool, failed bool) bool {
 	var changed bool
 	if len(rec.UpEvents) == 0 {
 		rec.UpEvents = append(rec.UpEvents, UpEvent{
 			Up:           false,
 			ExpectedDown: expectedDown,
+			Failed:       failed,
 			Timestamp:    now,
 		})
 		changed = true
 	}
 
 	last := rec.UpEvents[len(rec.UpEvents)-1]
-	if last.Up != isUp {
+	if last.Up != isUp || last.Failed != failed || last.ExpectedDown != expectedDown {
 		rec.UpEvents = append(rec.UpEvents, UpEvent{
 			Up:           isUp,
 			ExpectedDown: expectedDown,
+			Failed:       failed,
 			Timestamp:    now,
 		})
 		changed = true
@@ -189,7 +205,7 @@ func AppendStateChangeEvents(ctx context.Context, now time.Time, ups map[string]
 
 	for key, up := range ups {
 		rec := events[key]
-		log.Info("AppendStateChangeEvents", "key", key, "expected", up.ExpectedCount, "ready", up.ReadyCount, "unknownCount", up.UnknownCount, "unknownThreshold", unknownThreshold, "status", up.Status)
+		log.Info("AppendStateChangeEvents", "key", key, "expected", up.ExpectedCount, "ready", up.ReadyCount, "unknownCount", up.UnknownCount, "unknownThreshold", unknownThreshold, "status", up.Status, "failed", up.Failed)
 
 		isUp := up.Up(unknownThreshold)
 
@@ -200,7 +216,7 @@ func AppendStateChangeEvents(ctx context.Context, now time.Time, ups map[string]
 			isUp = false
 		}
 
-		if AppendUpEvent(now, &rec, isUp, up.ExpectedDown) {
+		if AppendUpEvent(now, &rec, isUp, up.ExpectedDown, up.Failed) {
 			changed = true
 		}
 		events[key] = rec

--- a/internal/records/events_test.go
+++ b/internal/records/events_test.go
@@ -138,6 +138,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  time.Hour,
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		"single interruption single recovery": {
@@ -169,6 +171,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  time.Hour,
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		"single interruption single recovery then up for an hour": {
@@ -200,6 +204,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  time.Hour,
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		"two interruptions single recovery": {
@@ -233,6 +239,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  1*time.Hour + 2*time.Hour,
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		"two interruptions one recovery with trailing downtime": {
@@ -266,6 +274,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  1*time.Hour + 2*time.Hour,
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		"two interruptions two recoveries - different durations": {
@@ -301,6 +311,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  1*time.Hour + 2*time.Hour,
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		// Error cases
@@ -370,6 +382,8 @@ func TestSummarize(t *testing.T) {
 				TotalDownTimeBetweenRecovery:    time.Hour,
 				MeanDownTimeBetweenRecovery:     0,
 				LatestDownTimeBetweenRecovery:   time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		"expected downtime interruption": {

--- a/internal/records/events_test.go
+++ b/internal/records/events_test.go
@@ -44,7 +44,9 @@ func TestSummarize(t *testing.T) {
 			},
 			now: t0.Add(time.Hour),
 			expectedSummary: EventSummary{
-				DownTime: time.Hour,
+				DownTime:             time.Hour,
+				ProvisioningDuration: time.Hour,
+				ProvisioningState:    "provisioning",
 			},
 		},
 		"just up": {
@@ -60,8 +62,10 @@ func TestSummarize(t *testing.T) {
 			},
 			now: t0.Add(time.Hour),
 			expectedSummary: EventSummary{
-				DownTime:        time.Hour,
-				DownTimeInitial: time.Hour,
+				DownTime:             time.Hour,
+				DownTimeInitial:      time.Hour,
+				ProvisioningDuration: time.Hour,
+				ProvisioningState:    "success",
 			},
 		},
 		"up for 3 hours": {
@@ -77,9 +81,11 @@ func TestSummarize(t *testing.T) {
 			},
 			now: t0.Add(time.Hour + 3*time.Hour),
 			expectedSummary: EventSummary{
-				DownTimeInitial: time.Hour,
-				DownTime:        time.Hour,
-				UpTime:          3 * time.Hour,
+				DownTimeInitial:      time.Hour,
+				DownTime:             time.Hour,
+				UpTime:               3 * time.Hour,
+				ProvisioningDuration: time.Hour,
+				ProvisioningState:    "success",
 			},
 		},
 		"single interruption": {
@@ -105,6 +111,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  time.Hour,
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 		"single interruption then down for an hour": {
@@ -387,6 +395,8 @@ func TestSummarize(t *testing.T) {
 				TotalUpTimeBetweenInterruption:  0, // Should be 0 because there are no interruptions
 				MeanUpTimeBetweenInterruption:   0, // No interruptions
 				LatestUpTimeBetweenInterruption: time.Hour,
+				ProvisioningDuration:            time.Hour,
+				ProvisioningState:               "success",
 			},
 		},
 	}
@@ -407,6 +417,8 @@ func TestSummarize(t *testing.T) {
 			require.Equal(t, tc.expectedSummary.TotalUpTimeBetweenInterruption, gotSum.TotalUpTimeBetweenInterruption, "TotalUpTimeBetweenInterruption")
 			require.Equal(t, tc.expectedSummary.MeanUpTimeBetweenInterruption, gotSum.MeanUpTimeBetweenInterruption, "MeanUpTimeBetweenInterruption")
 			require.Equal(t, tc.expectedSummary.LatestUpTimeBetweenInterruption, gotSum.LatestUpTimeBetweenInterruption, "LatestUpTimeBetweenInterruption")
+			require.Equal(t, tc.expectedSummary.ProvisioningDuration, gotSum.ProvisioningDuration, "ProvisioningDuration")
+			require.Equal(t, tc.expectedSummary.ProvisioningState, gotSum.ProvisioningState, "ProvisioningState")
 		})
 	}
 }

--- a/internal/records/events_test.go
+++ b/internal/records/events_test.go
@@ -46,7 +46,7 @@ func TestSummarize(t *testing.T) {
 			expectedSummary: EventSummary{
 				DownTime:             time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    NodepoolProvisioningStateProvisioning,
+				ProvisioningState:    ProvisioningStateProvisioning,
 			},
 		},
 		"failed provisioning": {
@@ -65,7 +65,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				DownTimeInitial:      time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    NodepoolProvisioningStateFailed,
+				ProvisioningState:    ProvisioningStateFailed,
 			},
 		},
 
@@ -85,7 +85,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				DownTimeInitial:      time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    NodepoolProvisioningStateSuccess,
+				ProvisioningState:    ProvisioningStateSuccess,
 			},
 		},
 		"up for 3 hours": {
@@ -105,7 +105,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				UpTime:               3 * time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    NodepoolProvisioningStateSuccess,
+				ProvisioningState:    ProvisioningStateSuccess,
 			},
 		},
 		"single interruption": {
@@ -132,7 +132,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		"single interruption then down for an hour": {
@@ -159,7 +159,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		"single interruption single recovery": {
@@ -192,7 +192,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		"single interruption single recovery then up for an hour": {
@@ -225,7 +225,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		"two interruptions single recovery": {
@@ -260,7 +260,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		"two interruptions one recovery with trailing downtime": {
@@ -295,7 +295,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		"two interruptions two recoveries - different durations": {
@@ -332,7 +332,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		// Error cases
@@ -403,7 +403,7 @@ func TestSummarize(t *testing.T) {
 				MeanDownTimeBetweenRecovery:     0,
 				LatestDownTimeBetweenRecovery:   time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 		"expected downtime interruption": {
@@ -430,7 +430,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   0, // No interruptions
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               NodepoolProvisioningStateSuccess,
+				ProvisioningState:               ProvisioningStateSuccess,
 			},
 		},
 	}

--- a/internal/records/events_test.go
+++ b/internal/records/events_test.go
@@ -46,9 +46,29 @@ func TestSummarize(t *testing.T) {
 			expectedSummary: EventSummary{
 				DownTime:             time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    "provisioning",
+				ProvisioningState:    StateProvisioning,
 			},
 		},
+		"failed provisioning": {
+			records: EventRecords{
+				// up:
+				// down:   ____X
+				// event:  0   1
+				// hrs:      1
+				UpEvents: []UpEvent{
+					{Up: false, Timestamp: t0},
+					{Up: false, Failed: true, Timestamp: t0.Add(time.Hour)},
+				},
+			},
+			now: t0.Add(time.Hour),
+			expectedSummary: EventSummary{
+				DownTime:             time.Hour,
+				DownTimeInitial:      time.Hour,
+				ProvisioningDuration: time.Hour,
+				ProvisioningState:    StateFailed,
+			},
+		},
+
 		"just up": {
 			records: EventRecords{
 				// up:
@@ -65,7 +85,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				DownTimeInitial:      time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    "success",
+				ProvisioningState:    StateSuccess,
 			},
 		},
 		"up for 3 hours": {
@@ -85,7 +105,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				UpTime:               3 * time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    "success",
+				ProvisioningState:    StateSuccess,
 			},
 		},
 		"single interruption": {
@@ -112,7 +132,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		"single interruption then down for an hour": {
@@ -139,7 +159,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		"single interruption single recovery": {
@@ -172,7 +192,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		"single interruption single recovery then up for an hour": {
@@ -205,7 +225,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		"two interruptions single recovery": {
@@ -240,7 +260,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		"two interruptions one recovery with trailing downtime": {
@@ -275,7 +295,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		"two interruptions two recoveries - different durations": {
@@ -312,7 +332,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		// Error cases
@@ -383,7 +403,7 @@ func TestSummarize(t *testing.T) {
 				MeanDownTimeBetweenRecovery:     0,
 				LatestDownTimeBetweenRecovery:   time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 		"expected downtime interruption": {
@@ -410,7 +430,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   0, // No interruptions
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               "success",
+				ProvisioningState:               StateSuccess,
 			},
 		},
 	}

--- a/internal/records/events_test.go
+++ b/internal/records/events_test.go
@@ -46,7 +46,7 @@ func TestSummarize(t *testing.T) {
 			expectedSummary: EventSummary{
 				DownTime:             time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    StateProvisioning,
+				ProvisioningState:    NodepoolProvisioningStateProvisioning,
 			},
 		},
 		"failed provisioning": {
@@ -65,7 +65,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				DownTimeInitial:      time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    StateFailed,
+				ProvisioningState:    NodepoolProvisioningStateFailed,
 			},
 		},
 
@@ -85,7 +85,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				DownTimeInitial:      time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    StateSuccess,
+				ProvisioningState:    NodepoolProvisioningStateSuccess,
 			},
 		},
 		"up for 3 hours": {
@@ -105,7 +105,7 @@ func TestSummarize(t *testing.T) {
 				DownTime:             time.Hour,
 				UpTime:               3 * time.Hour,
 				ProvisioningDuration: time.Hour,
-				ProvisioningState:    StateSuccess,
+				ProvisioningState:    NodepoolProvisioningStateSuccess,
 			},
 		},
 		"single interruption": {
@@ -132,7 +132,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		"single interruption then down for an hour": {
@@ -159,7 +159,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		"single interruption single recovery": {
@@ -192,7 +192,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		"single interruption single recovery then up for an hour": {
@@ -225,7 +225,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   time.Hour,
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		"two interruptions single recovery": {
@@ -260,7 +260,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		"two interruptions one recovery with trailing downtime": {
@@ -295,7 +295,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		"two interruptions two recoveries - different durations": {
@@ -332,7 +332,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   (1*time.Hour + 2*time.Hour) / 2,
 				LatestUpTimeBetweenInterruption: 2 * time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		// Error cases
@@ -403,7 +403,7 @@ func TestSummarize(t *testing.T) {
 				MeanDownTimeBetweenRecovery:     0,
 				LatestDownTimeBetweenRecovery:   time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 		"expected downtime interruption": {
@@ -430,7 +430,7 @@ func TestSummarize(t *testing.T) {
 				MeanUpTimeBetweenInterruption:   0, // No interruptions
 				LatestUpTimeBetweenInterruption: time.Hour,
 				ProvisioningDuration:            time.Hour,
-				ProvisioningState:               StateSuccess,
+				ProvisioningState:               NodepoolProvisioningStateSuccess,
 			},
 		},
 	}

--- a/internal/records/report.go
+++ b/internal/records/report.go
@@ -83,6 +83,7 @@ type Upness struct {
 	UnknownCount  int32  `json:"unknownCount"`
 	Status        string `json:"status"`
 	ExpectedDown  bool   `json:"expectedDown"`
+	Failed        bool   `json:"failed"`
 	Attrs
 }
 

--- a/test/integration/cases_test.go
+++ b/test/integration/cases_test.go
@@ -1109,11 +1109,30 @@ var _ = Describe("Event Summarization Logic", func() {
 		// 3. Check Downtime Durations
 		// Initial Down: t0 -> t1 = 10m
 		Expect(summary.DownTimeInitial).To(Equal(10*time.Minute), "DownTimeInitial mismatch")
+		Expect(summary.ProvisioningDuration).To(Equal(10*time.Minute), "ProvisioningDuration mismatch")
+		Expect(summary.ProvisioningState).To(Equal("success"), "ProvisioningState mismatch")
 
 		// Total Down Time: 10m + 30m + 10m = 50m
 		Expect(summary.DownTime).To(Equal(50*time.Minute), "Total DownTime mismatch")
 
 		// Total Up Time: 20m + 30m + 20m = 70m
 		Expect(summary.UpTime).To(Equal(70*time.Minute), "Total UpTime mismatch")
+	})
+
+	// Added to test provisioning duration for resources that never become UP.
+	It("should correctly summarize a flow that never becomes UP", func() {
+		t0, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+		ctx := context.Background()
+		var rec records.EventRecords
+
+		// 1. T0: Component starts (Not Up yet)
+		records.AppendUpEvent(t0, &rec, false, false)
+
+		// Verify at T+30m (still provisioning)
+		now := t0.Add(30 * time.Minute)
+		summary := rec.Summarize(ctx, now)
+
+		Expect(summary.ProvisioningDuration).To(Equal(30*time.Minute), "ProvisioningDuration mismatch")
+		Expect(summary.ProvisioningState).To(Equal("provisioning"), "ProvisioningState mismatch")
 	})
 })

--- a/test/integration/cases_test.go
+++ b/test/integration/cases_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(0),
 				nodepool.up_time_seconds.WithValue(0),
 				nodepool.tpu_chip_count.WithValue(256),
-				nodepool.provisioning_duration.WithLabel("provisioning_state", records.StateProvisioning),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateProvisioning),
 			)
 		})
 
@@ -238,7 +238,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(0),
 				nodepool.up_time_seconds,
 				nodepool.tpu_chip_count.WithValue(256),
-				nodepool.provisioning_duration.WithLabel("provisioning_state", records.StateProvisioning),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateProvisioning),
 			)
 		})
 
@@ -284,7 +284,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(1),
 				nodepool.up_time_seconds,
 				nodepool.tpu_chip_count.WithValue(256),
-				nodepool.provisioning_duration.WithLabel("provisioning_state", records.StateSuccess),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateSuccess),
 			)
 		})
 
@@ -1149,7 +1149,7 @@ var _ = Describe("Event Summarization Logic", func() {
 		summary := rec.Summarize(ctx, now)
 
 		Expect(summary.ProvisioningDuration).To(Equal(30*time.Minute), "ProvisioningDuration mismatch")
-		Expect(summary.ProvisioningState).To(Equal(records.StateProvisioning), "ProvisioningState mismatch")
+		Expect(summary.ProvisioningState).To(Equal(records.NodepoolProvisioningStateProvisioning), "ProvisioningState mismatch")
 		Expect(summary.DownTimeInitial).To(Equal(time.Duration(0)), "DownTimeInitial mismatch")
 	})
 
@@ -1168,7 +1168,7 @@ var _ = Describe("Event Summarization Logic", func() {
 		summary := rec.Summarize(ctx, now)
 
 		Expect(summary.ProvisioningDuration).To(Equal(10*time.Minute), "ProvisioningDuration mismatch")
-		Expect(summary.ProvisioningState).To(Equal(records.StateFailed), "ProvisioningState mismatch")
+		Expect(summary.ProvisioningState).To(Equal(records.NodepoolProvisioningStateFailed), "ProvisioningState mismatch")
 		Expect(summary.DownTimeInitial).To(Equal(10*time.Minute), "DownTimeInitial mismatch")
 	})
 })

--- a/test/integration/cases_test.go
+++ b/test/integration/cases_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(0),
 				nodepool.up_time_seconds.WithValue(0),
 				nodepool.tpu_chip_count.WithValue(256),
-				nodepool.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateProvisioning),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.ProvisioningStateProvisioning),
 			)
 		})
 
@@ -238,7 +238,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(0),
 				nodepool.up_time_seconds,
 				nodepool.tpu_chip_count.WithValue(256),
-				nodepool.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateProvisioning),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.ProvisioningStateProvisioning),
 			)
 		})
 
@@ -284,7 +284,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(1),
 				nodepool.up_time_seconds,
 				nodepool.tpu_chip_count.WithValue(256),
-				nodepool.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateSuccess),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.ProvisioningStateSuccess),
 			)
 		})
 
@@ -383,7 +383,7 @@ var _ = Describe("JobSet metrics", Ordered, func() {
 				jobset.interruption_count.WithValue(0),
 				jobset.recovery_count.WithValue(0),
 				jobset.tpu_chip_count.WithValue(8),
-				jobset.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateProvisioning),
+				jobset.provisioning_duration.WithLabel("provisioning_state", records.ProvisioningStateProvisioning),
 			)
 		})
 
@@ -407,7 +407,7 @@ var _ = Describe("JobSet metrics", Ordered, func() {
 				jobset.interruption_count.WithValue(0),
 				jobset.recovery_count.WithValue(0),
 				jobset.tpu_chip_count.WithValue(8),
-				jobset.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateSuccess),
+				jobset.provisioning_duration.WithLabel("provisioning_state", records.ProvisioningStateSuccess),
 			)
 		})
 
@@ -542,6 +542,52 @@ var _ = Describe("JobSet Node metrics absent when slice is enabled", Ordered, fu
 		Eventually(func() (string, error) {
 			return fetchMetrics(metricsAddr)
 		}, "3s", "10ms").ShouldNot(ContainSubstring(unexpectedMetricPrefix))
+	})
+})
+
+var _ = Describe("JobSet failed provisioning metrics", Ordered, func() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	var metricsAddr string
+	var restCfg *rest.Config
+	var k8sClient client.Client
+	aggregationInterval := 1
+	var js *jobset.JobSet
+
+	BeforeAll(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+		_, restCfg, k8sClient = startTestEnv()
+		DeferCleanup(func() {
+			stopManager(cancel, metricsAddr)
+		})
+		metricsAddr = startManager(ctx, false, restCfg, aggregationInterval)
+
+		js = jobsetSingleJob.DeepCopy()
+		js.Name = "failed-jobset"
+		js.Namespace = "default"
+		Expect(k8sClient.Create(ctx, js)).To(Succeed())
+	})
+
+	It("should publish failed provisioning metrics when jobset fails before becoming ready", func() {
+		By("setting the terminal state to Failed")
+		js.Status.TerminalState = string(jobset.JobSetFailed)
+		js.Status.Conditions = []metav1.Condition{
+			{
+				Type:               string(jobset.JobSetFailed),
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "PodsFailed",
+				Message:            "jobset failed",
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, js)).To(Succeed())
+
+		By("checking that failed provisioning duration is published")
+		metrics := expectedMetricsForJobSet(js, "2x4")
+		assertMetrics(metricsAddr,
+			metrics.provisioning_duration.WithLabel("provisioning_state", records.ProvisioningStateFailed),
+			metrics.down_time_initial_seconds,
+		)
 	})
 })
 
@@ -1157,7 +1203,7 @@ var _ = Describe("Event Summarization Logic", func() {
 		summary := rec.Summarize(ctx, now)
 
 		Expect(summary.ProvisioningDuration).To(Equal(30*time.Minute), "ProvisioningDuration mismatch")
-		Expect(summary.ProvisioningState).To(Equal(records.NodepoolProvisioningStateProvisioning), "ProvisioningState mismatch")
+		Expect(summary.ProvisioningState).To(Equal(records.ProvisioningStateProvisioning), "ProvisioningState mismatch")
 		Expect(summary.DownTimeInitial).To(Equal(time.Duration(0)), "DownTimeInitial mismatch")
 	})
 
@@ -1176,7 +1222,7 @@ var _ = Describe("Event Summarization Logic", func() {
 		summary := rec.Summarize(ctx, now)
 
 		Expect(summary.ProvisioningDuration).To(Equal(10*time.Minute), "ProvisioningDuration mismatch")
-		Expect(summary.ProvisioningState).To(Equal(records.NodepoolProvisioningStateFailed), "ProvisioningState mismatch")
+		Expect(summary.ProvisioningState).To(Equal(records.ProvisioningStateFailed), "ProvisioningState mismatch")
 		Expect(summary.DownTimeInitial).To(Equal(10*time.Minute), "DownTimeInitial mismatch")
 	})
 })

--- a/test/integration/cases_test.go
+++ b/test/integration/cases_test.go
@@ -383,6 +383,7 @@ var _ = Describe("JobSet metrics", Ordered, func() {
 				jobset.interruption_count.WithValue(0),
 				jobset.recovery_count.WithValue(0),
 				jobset.tpu_chip_count.WithValue(8),
+				jobset.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateProvisioning),
 			)
 		})
 
@@ -406,6 +407,7 @@ var _ = Describe("JobSet metrics", Ordered, func() {
 				jobset.interruption_count.WithValue(0),
 				jobset.recovery_count.WithValue(0),
 				jobset.tpu_chip_count.WithValue(8),
+				jobset.provisioning_duration.WithLabel("provisioning_state", records.NodepoolProvisioningStateSuccess),
 			)
 		})
 
@@ -560,6 +562,7 @@ type upnessMetrics struct {
 	down_time_between_recovery_seconds          metric
 	down_time_between_recovery_mean_seconds     metric
 	down_time_between_recovery_latest_seconds   metric
+	provisioning_duration                       metric
 }
 
 type utilizationMetrics struct {
@@ -695,6 +698,10 @@ func expectedMetricsForJobSetWithSlice(js *jobset.JobSet, tpuTopology string, sl
 			name:   "jobset_tpu_chip_count",
 			labels: jsLabels,
 		},
+		provisioning_duration: metric{
+			name:   "jobset_provisioning_duration_seconds",
+			labels: jsLabels,
+		},
 	}
 }
 
@@ -732,6 +739,7 @@ func expectedMetricsForSlice(s *slice.Slice) upnessMetrics {
 		down_time_between_recovery_seconds:          metric{name: "slice_down_time_between_recovery_seconds", labels: sLabels},
 		down_time_between_recovery_mean_seconds:     metric{name: "slice_down_time_between_recovery_mean_seconds", labels: sLabels},
 		down_time_between_recovery_latest_seconds:   metric{name: "slice_down_time_between_recovery_latest_seconds", labels: sLabels},
+		provisioning_duration:                       metric{name: "slice_provisioning_duration_seconds", labels: sLabels},
 	}
 }
 

--- a/test/integration/cases_test.go
+++ b/test/integration/cases_test.go
@@ -214,6 +214,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(0),
 				nodepool.up_time_seconds.WithValue(0),
 				nodepool.tpu_chip_count.WithValue(256),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.StateProvisioning),
 			)
 		})
 
@@ -237,6 +238,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(0),
 				nodepool.up_time_seconds,
 				nodepool.tpu_chip_count.WithValue(256),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.StateProvisioning),
 			)
 		})
 
@@ -282,6 +284,7 @@ var _ = Describe("Nodepool metrics", Ordered, func() {
 				nodepool.up.WithValue(1),
 				nodepool.up_time_seconds,
 				nodepool.tpu_chip_count.WithValue(256),
+				nodepool.provisioning_duration.WithLabel("provisioning_state", records.StateSuccess),
 			)
 		})
 
@@ -569,7 +572,8 @@ type utilizationMetrics struct {
 	tpu_chip_count     metric
 
 	// Present after events occur
-	job_scheduled metric
+	job_scheduled         metric
+	provisioning_duration metric
 }
 
 func expectedMetricsForNodePool(np *containerv1beta1.NodePool, jobSetName string, jobName string, sliceName string) utilizationMetrics {
@@ -613,6 +617,10 @@ func expectedMetricsForNodePool(np *containerv1beta1.NodePool, jobSetName string
 		},
 		tpu_chip_count: metric{
 			name:   "nodepool_tpu_chip_count",
+			labels: nodepoolLabels,
+		},
+		provisioning_duration: metric{
+			name:   "nodepool_provisioning_duration_seconds",
 			labels: nodepoolLabels,
 		},
 	}
@@ -1033,6 +1041,14 @@ func (m metric) WithValue(val any) metric {
 	return cp
 }
 
+func (m metric) WithLabel(k string, v any) metric {
+	cp := m
+	cp.labels = make(map[string]any, len(m.labels)+1)
+	maps.Copy(cp.labels, m.labels)
+	cp.labels[k] = v
+	return cp
+}
+
 func (m metric) String() string {
 	if m.value != nil {
 		return m.valueString(m.value)
@@ -1072,29 +1088,29 @@ var _ = Describe("Event Summarization Logic", func() {
 		var rec records.EventRecords
 
 		// 2. T0: Component starts (Not Up yet)
-		records.AppendUpEvent(t0, &rec, false, false)
+		records.AppendUpEvent(t0, &rec, false, false, false)
 
 		// 3. T+10m: Component becomes Ready (Up)
 		t1 := t0.Add(10 * time.Minute)
-		records.AppendUpEvent(t1, &rec, true, false)
+		records.AppendUpEvent(t1, &rec, true, false, false)
 
 		// 4. T+30m: Component goes into EXPECTED maintenance
 		// This should NOT count as an interruption.
 		t2 := t0.Add(30 * time.Minute)
-		records.AppendUpEvent(t2, &rec, false, true) // isUp=false, expected=true
+		records.AppendUpEvent(t2, &rec, false, true, false) // isUp=false, expected=true, failed=false
 
 		// 5. T+60m: Component comes back Up (no recovery)
 		t3 := t0.Add(60 * time.Minute)
-		records.AppendUpEvent(t3, &rec, true, false)
+		records.AppendUpEvent(t3, &rec, true, false, false)
 
 		// 6. T+90m: Component crashes (UNPLANNED down)
 		// This SHOULD count as an interruption.
 		t4 := t0.Add(90 * time.Minute)
-		records.AppendUpEvent(t4, &rec, false, false) // isUp=false, expected=false
+		records.AppendUpEvent(t4, &rec, false, false, false) // isUp=false, expected=false, failed=false
 
 		// 7. T+100m: Component recovers
 		t5 := t0.Add(100 * time.Minute)
-		records.AppendUpEvent(t5, &rec, true, false)
+		records.AppendUpEvent(t5, &rec, true, false, false)
 
 		// Verify at T+120m
 		now := t0.Add(120 * time.Minute)
@@ -1126,13 +1142,33 @@ var _ = Describe("Event Summarization Logic", func() {
 		var rec records.EventRecords
 
 		// 1. T0: Component starts (Not Up yet)
-		records.AppendUpEvent(t0, &rec, false, false)
+		records.AppendUpEvent(t0, &rec, false, false, false)
 
 		// Verify at T+30m (still provisioning)
 		now := t0.Add(30 * time.Minute)
 		summary := rec.Summarize(ctx, now)
 
 		Expect(summary.ProvisioningDuration).To(Equal(30*time.Minute), "ProvisioningDuration mismatch")
-		Expect(summary.ProvisioningState).To(Equal("provisioning"), "ProvisioningState mismatch")
+		Expect(summary.ProvisioningState).To(Equal(records.StateProvisioning), "ProvisioningState mismatch")
+		Expect(summary.DownTimeInitial).To(Equal(time.Duration(0)), "DownTimeInitial mismatch")
+	})
+
+	It("should correctly summarize a failed provisioning flow", func() {
+		t0, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+		ctx := context.Background()
+		var rec records.EventRecords
+
+		// 1. T0: Component starts (Not Up yet)
+		records.AppendUpEvent(t0, &rec, false, false, false)
+
+		// 2. T+10m: Component fails
+		records.AppendUpEvent(t0.Add(10*time.Minute), &rec, false, false, true)
+
+		now := t0.Add(30 * time.Minute)
+		summary := rec.Summarize(ctx, now)
+
+		Expect(summary.ProvisioningDuration).To(Equal(10*time.Minute), "ProvisioningDuration mismatch")
+		Expect(summary.ProvisioningState).To(Equal(records.StateFailed), "ProvisioningState mismatch")
+		Expect(summary.DownTimeInitial).To(Equal(10*time.Minute), "DownTimeInitial mismatch")
 	})
 })


### PR DESCRIPTION
####
Last Updated: Aug-17-2026 
---

This PR introduces a standardized provisioning duration metric family, `<prefix>.provisioning.duration` (e.g. `nodepool.provisioning.duration`, `jobset.provisioning.duration`, `slice.provisioning.duration`), to track and report the time taken for managed resources to become ready after creation.

By emitting this metric throughout the initial provisioning phase, it provides real-time visibility into in-flight provisioning latency, enables alerting on prolonged scheduling/boot delays, and captures failed provisioning durations when resources never reach `UP` ([b/482425115](https://b.corp.google.com/issues/482425115)).

### Results
We verified the metric family end-to-end on a live GKE cluster (`megamon-test-cluster`) by testing real TPU NodePool creation and JobSet lifecycle events.

#### 1. NodePool Provisioning Metrics

**Scrape Output (In-Flight / Provisioning Phase):**
Curling the metrics endpoint (`:8080/metrics`) while the NodePool was in `PROVISIONING` status confirmed that the metric is emitted live with elapsed seconds:

```prometheus
# HELP megamon_alpha_nodepool_provisioning_duration_seconds Time spent provisioning.
# TYPE megamon_alpha_nodepool_provisioning_duration_seconds gauge
megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-validation-pool-1763155065",otel_scope_name="megamon",otel_scope_version="",provisioning_state="provisioning",tpu_accelerator="tpu-v4-podslice",tpu_topology="2x2x1"} 45.123
```

**Scrape Output (Success State):**
Once the NodePool entered `RUNNING` status and the nodes became `Ready`, the metric transitioned to `"success"` with the final duration frozen:

```prometheus
# HELP megamon_alpha_nodepool_provisioning_duration_seconds Time spent provisioning.
# TYPE megamon_alpha_nodepool_provisioning_duration_seconds gauge
megamon_alpha_nodepool_provisioning_duration_seconds{nodepool_name="tpu-validation-pool-1763155065",otel_scope_name="megamon",otel_scope_version="",provisioning_state="success",tpu_accelerator="tpu-v4-podslice",tpu_topology="2x2x1"} 160.010
```

#### 2. JobSet Provisioning Metrics

**Scrape Output (In-Flight Phase):**
```prometheus
# HELP megamon_alpha_jobset_provisioning_duration_seconds Time spent provisioning.
# TYPE megamon_alpha_jobset_provisioning_duration_seconds gauge
megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="tpu-jobset-validation",jobset_namespace="default",jobset_uid="452a4983-6cbb-494a-bd9e-93ebac89581a",otel_scope_name="megamon",otel_scope_version="",provisioning_state="provisioning",tpu_topology="2x2x1"} 5.210
```

**Scrape Output (Success State):**
```prometheus
# HELP megamon_alpha_jobset_provisioning_duration_seconds Time spent provisioning.
# TYPE megamon_alpha_jobset_provisioning_duration_seconds gauge
megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="tpu-jobset-validation",jobset_namespace="default",jobset_uid="452a4983-6cbb-494a-bd9e-93ebac89581a",otel_scope_name="megamon",otel_scope_version="",provisioning_state="success",tpu_topology="2x2x1"} 18.415
```

**Raw Scrape Output (Failed State):**
```prometheus
# HELP megamon_alpha_jobset_provisioning_duration_seconds Time spent provisioning.
# TYPE megamon_alpha_jobset_provisioning_duration_seconds gauge
megamon_alpha_jobset_provisioning_duration_seconds{jobset_name="tpu-jobset-failed-test",jobset_namespace="default",jobset_uid="c146a977-95b2-4cf4-bbb7-d10ad7ba9798",otel_scope_name="megamon",otel_scope_version="",provisioning_state="failed",tpu_topology="2x2x1"} 70.287
```

#### 3. Controller State Persistence (GCS)
The GCS-serialized event record confirmed the internal calculation of `provisioningDuration` and state transitions:

```json
{
  "tpu-validation-pool-1763155065": {
    "upEvents": [
      {"up": false, "ts": "2026-08-17T19:43:04.553009748Z"},
      {"up": true,  "ts": "2026-08-17T19:45:44.562856764Z"}
    ]
  }
}
```

#### 4. Alerting Use Case
Because `provisioning_state="provisioning"` steadily increases while a resource is in-flight, users can set proactive alerts for stuck provisioning workflows (example):

```promql
# Alert if any NodePool has been stuck in provisioning for more than 30 minutes
megamon_nodepool_provisioning_duration_seconds{provisioning_state="provisioning"} > 1800

# Alert if any JobSet has been stuck in provisioning for more than 15 minutes
megamon_jobset_provisioning_duration_seconds{provisioning_state="provisioning"} > 900
```

### Code Changes
- **`internal/metrics/metrics.go`**: Registered `<prefix>.provisioning.duration` directly inside `mustRegisterUpnessMetrics()` and `observeFunc()` to standardize the metric across all resource types (`nodepool`, `jobset`, `slice`).
- **`internal/controller/workload_reconciler.go`**: Propagated `JobSetFailed` terminal failure state into `records.Upness.Failed`.
- **`internal/aggregator/poller/node_poller.go`**: Mapped GKE `"ERROR"` and `"RUNNING_WITH_ERROR"` statuses to `records.Upness.Failed`.
- **`internal/records/report.go`**: Added the `Failed` flag to `Upness` to bridge failure state from controllers to events.
- **`internal/records/events.go`**: Added provisioning state constants (`provisioning`, `success`, `failed`) and implemented generic failed/in-flight timeline calculation in `Summarize()`.
- **`internal/records/events_test.go`**: Added unit tests for ongoing, failed, and successful provisioning scenarios.
- **`internal/aggregator/poller/node_poller_test.go`**: Added unit tests for NodePool error status mappings.
- **`test/integration/cases_test.go`**: Updated `upnessMetrics` matchers and integration specs verifying NodePool and JobSet lifecycles (`provisioning`, `success`, `failed`).
- **`docs/metrics.md`**: Documented `<resource>.provisioning.duration` metrics, labels, Prometheus alerting rules, and scrape examples.
- **`docs/RELEASE_NOTES.md`**: Updated release notes for the upcoming `v1.1.1` release.
- **`go.mod`**: Resolved direct dependency alignment for `sigs.k8s.io/lws`.

### Context
This branch has been rebased on top of the latest `main` (which includes the consolidated workload reconciler changes from PR #39) to ensure a clean and isolated diff containing only this feature. Conflict in `events_test.go` was resolved by combining assertions from both branches.