### PR TITLE
configure slice owner configmap in default-slice kustomize

### DIFF
--- a/config/default-slice/kustomization.yaml
+++ b/config/default-slice/kustomization.yaml
@@ -1,5 +1,11 @@
 resources:
 - ../default
+- slice_owner_map.yaml
+
+namespace: megamon-system
+
+generatorOptions:
+  disableNameSuffixHash: true
 
 patches:
 - patch: |-

--- a/config/default-slice/slice_owner_map.yaml
+++ b/config/default-slice/slice_owner_map.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: megamon-slice-owner-map


### PR DESCRIPTION
This will create the slice owner configmap if it doesn't exist